### PR TITLE
Accomodate deprecations in 1.36 and greater

### DIFF
--- a/Jony/Jony.skin.php
+++ b/Jony/Jony.skin.php
@@ -9,19 +9,29 @@ class SkinJony extends SkinTemplate {
 		$template = 'JonyTemplate', $useHeadElement = true;
 
 	/**
+	 * @inheritDoc
+	 */
+	public function __construct( $options ) {
+		$options['bodyOnly'] = true;
+		parent::__construct( $options );
+	}
+
+	/**
 	 * Add CSS via ResourceLoader
 	 *
 	 * @param $out OutputPage
 	 */
 	public function initPage( OutputPage $out ) {
-
-		$out->addModuleStyles( array(
-			'mediawiki.skinning.interface',
-			'mediawiki.skinning.content.externallinks',
-			'skins.jony'
-		) );
-/*		$out->addModules( array(
-			'skins.jony.js'
-		) );*/
+		if ( version_compare( MW_VERSION, '1.36', '<' ) ) {
+			$out->addModuleStyles( [
+				'mediawiki.skinning.interface',
+				'mediawiki.skinning.content.externallinks',
+				'skins.jony'
+			] );
+		} else {
+			$out->addModuleStyles( [
+				'skins.jony.styles'
+			] );
+		}
 	}
 }

--- a/Jony/JonyTemplate.php
+++ b/Jony/JonyTemplate.php
@@ -9,7 +9,9 @@ class JonyTemplate extends BaseTemplate {
 	 * Outputs the entire contents of the page
 	 */
 	public function execute() {
-		$this->html( 'headelement' );
+		if ( version_compare( MW_VERSION, '1.39', '<' ) ) {
+			$this->html( 'headelement' );
+		}
 		?>
 		<div id="mw-wrapper">
 			<?php
@@ -170,11 +172,11 @@ class JonyTemplate extends BaseTemplate {
 			</div>
 		</div>
 
-		<?php $this->printTrail() ?>
-		</body>
-		</html>
-
-		<?php
+		<?php 
+		if ( version_compare( MW_VERSION, '1.39', '<' ) ) {
+			$this->printTrail();
+			echo '</body></html>';
+		}
 	}
 
 	/**

--- a/Jony/skin.json
+++ b/Jony/skin.json
@@ -23,6 +23,32 @@
 		]
 	},
 	"ResourceModules": {
+		"skins.jony.styles": {
+			"class": "ResourceLoaderSkinModule",
+			"features": {
+				"content": true,
+				"content-thumbnails": true,
+				"content-tables": true,
+				"elements": true,
+				"i18n-ordered-lists": true,
+				"i18n-all-lists-margins": true,
+				"i18n-headings": true,
+				"interface": true,
+				"interface-message-box": true,
+				"interface-category": true,
+				"logo": true,
+				"content-links": true,
+				"content-links-external": true
+			},
+			"styles": {
+				"resources/print.less": {
+					"media": "print"
+				},
+				"resources/screen.less": {
+					"media": "screen"
+				}
+			}
+		},
 		"skins.jony": {
 			"position" : "top",
 			"styles": {


### PR DESCRIPTION
I've made this change use version_compare to keep compatibility
with whatever version you need to keep.

This change however will prevent breakage due to T304322
and deprecation warnings due to T306942